### PR TITLE
window.$$ = ....  prevents $$ from being seen in evaled scripts under IE7.

### DIFF
--- a/src/prototype/dom/selector.js
+++ b/src/prototype/dom/selector.js
@@ -83,7 +83,7 @@
  *      $$('div:empty');
  *      // -> all DIVs without content (i.e., whitespace-only)
 **/
-window.$$ = function() {
+function $$() {
   var expression = $A(arguments).join(', ');
   return Prototype.Selector.select(expression, document);
 };


### PR DESCRIPTION
Hello,

I ran into this issue while trying to upgrade to Prototype 1.7 for some old code.

At some point, the declaration for $$ changed from "function $$()" to "windows.$$ = ".  Unfortunately, I found that variables created in this manner are not available via "eval"ed scripts in IE7 (and possibly 6).  There are other variables for which this is also an issue, but I find $$ to be quite vital.  The others include:

window.HTMLElement
window.Sizzle
window.Event
window.Selector

Thank you,
Brett DiFrischia
