### PR TITLE
trying to fix prototype to be able to handle dom:load event properly

### DIFF
--- a/src/prototype/dom/event.js
+++ b/src/prototype/dom/event.js
@@ -1236,7 +1236,7 @@
   }
 
   function checkReadyState() {
-    if (document.readyState === 'complete') {
+    if (document.readyState && document.readyState === 'complete') {
       document.stopObserving('readystatechange', checkReadyState);
       fireContentLoadedEvent();
     }
@@ -1258,6 +1258,9 @@
     if (window == top)
       timer = pollDoScroll.defer();
   }
+
+  // check if document already loaded (ie, DOMContentLoaded already passed)
+  checkReadyState();
 
   // Worst-case fallback
   Event.observe(window, 'load', fireContentLoadedEvent);


### PR DESCRIPTION
If Prototype is loaded dynamically with a script loader, it currently doesn't "see" that the document's DOMContentLoaded/window.onload are already passed. This can be resolved simply by checking for document.readyState == "complete" right away when Prototype loads.

Moreover, if someone binds to the "dom:load" event after it's already passed, it would make a lot of sense for that specific special kind of event (ie, an event that is only ever a one-time fire event) to just fire the intended callback immediately. This is how jQuery handles this case.

The use case is that someone may create a widget (like the Starbox widget, which is what prompted me to look into this), which the widget uses Prototype. If that widget is loaded using normal script tags, the internal code needs to make sure to wrap its logic for DOM modifications in "dom:load" event handlers. But, of course, if that widget is loaded by a script loader later, after the page is already finished, the same code which is wrapped in "dom:load" handlers should just execute immediately.
