### PR TITLE
Fix for #1217 - Ensure compatibility with Closure Compiler

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+* Ensure that prototype works in IE < 9 when compiled via Closure Compiler [#1217 state:resolved] (Christopher Blum)
+
 *1.7* (November 16, 2010)
 
 * Ensure `Element#update` works with string content that includes a LINK tag in Internet Explorer. [#264 state:resolved] (Tobias H. Michaelsen, Andrew Dupont)

--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -81,7 +81,7 @@ if (Prototype.BrowserFeatures.XPath) {
 
 /*--------------------------------------------------------------------------*/
 
-if (!Node) var Node = { };
+if (!window.Node) var Node = { };
 
 if (!Node.ELEMENT_NODE) {
   // DOM level 2 ECMAScript Language Binding


### PR DESCRIPTION
More info here: https://prototype.lighthouseapp.com/projects/8886-prototype/tickets/1217-prototype-17-doesnt-work-when-compiled-via-closure-compiler
