### PR TITLE
Replaced named entity with character number for XHTML comatibility.

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3006,7 +3006,7 @@ Element._getContentFromAnonymousElement = function(tagName, html, force) {
   if (workaround) {
     // Adding a text node to the beginning of the string (then removing it)
     // fixes an issue in Internet Explorer. See Element#update above.
-    div.innerHTML = '&nbsp;' + t[0] + html + t[1];
+    div.innerHTML = '&#160;' + t[0] + html + t[1];
     div.removeChild(div.firstChild);
     for (var i = t[2]; i--; ) {
       div = div.firstChild;


### PR DESCRIPTION
Browsers have problems with HTML named entities when working in real XHTML mode (when page is served as application/xhtml+xml). It causes problems with innerHTML - throws exceptions about invalid pointer. This fixes the problem and still makes first element of innerHTML an whitespace entity.
