### PR TITLE
Addition to Element#insert to allow insertion into the target

### DIFF
--- a/src/dom/dom.js
+++ b/src/dom/dom.js
@@ -791,6 +791,9 @@
     after: function(element, node) {
       element.parentNode.insertBefore(node, element.nextSibling);
     },
+    into: function (element, node) {
+      node.appendChild(element);
+    },
     
     tags: {
       TABLE:  ['<table>',                '</table>',                   1],


### PR DESCRIPTION
Got this idea tonight while porting a jQuery plugin over to Prototype and having to convert many many instances of jQuery's .appendTo() function.  Passing `into` as the insertion point performs the reverse of a typical insert call, inserting the origin element into the target.

This would then allow me to turn the following jQuery code:

``` js
var scroller = $('<div class="visualize-scroller"></div>')
    .appendTo(canvasContain)
    .append(canvas);
```

into:

``` js
var scroller = new Element('div',{className:'visualize-scroller'})
    .insert({
        bottom:canvas, 
        into:canvasContain
    });
```

instead of:

``` js
var scroller = new Element('div',{className:'visualize-scroller'})
    .insert(canvas);
canvasContain.insert(scroller);
```
