### PR TITLE
avoiding infinite loop in String#gsub when there is a zero length match

### DIFF
--- a/src/prototype/lang/string.js
+++ b/src/prototype/lang/string.js
@@ -100,7 +100,8 @@ Object.extend(String.prototype, (function() {
     }
 
     while (source.length > 0) {
-      if (match = source.match(pattern)) {
+      match = source.match(pattern)
+      if (match && match[0].length > 0) {
         result += source.slice(0, match.index);
         result += String.interpret(replacement(match));
         source  = source.slice(match.index + match[0].length);

--- a/test/unit/string_test.js
+++ b/test/unit/string_test.js
@@ -66,7 +66,6 @@ new Test.Unit.Runner({
   
   testGsubWithTroublesomeCharacters: function() {
     this.assertEqual('ab', 'a|b'.gsub('|', ''));
-    //'ab'.gsub('', ''); // freeze
     this.assertEqual('ab', 'ab(?:)'.gsub('(?:)', ''));
     this.assertEqual('ab', 'ab()'.gsub('()', ''));
     this.assertEqual('ab', 'ab'.gsub('^', ''));
@@ -76,6 +75,12 @@ new Test.Unit.Runner({
     this.assertEqual('ab', 'a{1}b'.gsub('{1}', ''));
     this.assertEqual('ab', 'a.b'.gsub('.', ''));
   },  
+  
+  testGsubWithZeroLengthMatch: function() {
+    this.assertEqual('ab', 'ab'.gsub('', ''));
+    this.assertEqual('a', 'a'.gsub(/b*/, 'c'));
+    this.assertEqual('abc', 'abc'.gsub(/b{0}/, ''));
+  },
   
   testSubWithReplacementFunction: function() {
     var source = 'foo boo boz';


### PR DESCRIPTION
If you issue a sub() or a gsub() using a pattern that will generate a zero-length match, prototype will get locked in an infinite loop.  See tests for example patterns that trigger this behavior.
