### PR TITLE
Object.isNumber method "NaN" support

### DIFF
--- a/src/prototype/lang/object.js
+++ b/src/prototype/lang/object.js
@@ -537,7 +537,7 @@
    *      //-> false
   **/
   function isNumber(object) {
-    return _toString.call(object) === NUMBER_CLASS;
+    return _toString.call(object) === NUMBER_CLASS && !isNaN(object);
   }
   
   /**

--- a/test/unit/object_test.js
+++ b/test/unit/object_test.js
@@ -160,13 +160,17 @@ new Test.Unit.Runner({
   testObjectIsNumber: function() {
     this.assert(Object.isNumber(0));
     this.assert(Object.isNumber(1.0));
+    this.assert(Object.isNumber(parseInt("1",10)));
+    this.assert(Object.isNumber(parseInt("0x10")));
     this.assert(Object.isNumber(new Number(0)));
     this.assert(Object.isNumber(new Number(1.0)));
     this.assert(!Object.isNumber(function() { }));
     this.assert(!Object.isNumber({ test: function() { return 3 } }));
     this.assert(!Object.isNumber("a string"));
+    this.assert(!Object.isNumber(parseInt("a string",10))); //parseInt(String) returns NaN. Javascript handles NaN as a Number type
     this.assert(!Object.isNumber([]));
     this.assert(!Object.isNumber({}));
+    this.assert(!Object.isNumber(NaN));
     this.assert(!Object.isNumber(false));
     this.assert(!Object.isNumber(undefined));
     this.assert(!Object.isNumber(document), 'host objects should return false rather than throw exceptions');


### PR DESCRIPTION
I found this issue while validating some html form data. I needed to know if there was a valid number into a field. 
If we do parseInt() in a string that contains an invalid number,  the interpreter returns the value "NaN", and "NaN" is handled as a numeric type (bad). 
Object.isNumber(NaN) is returning true instead false. I made a change on the method for reject the value "NaN" as a number.
