### PR TITLE
Replaced named entity with character number for XHTML comatibility.

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -1125,7 +1125,7 @@
     }
     
     if (workaround) {
-      div.innerHTML = '&nbsp;' + t[0] + html + t[1];
+      div.innerHTML = '&#160;' + t[0] + html + t[1];
       div.removeChild(div.firstChild);
       for (var i = t[2]; i--; )
         div = div.firstChild;


### PR DESCRIPTION
Browsers have problems with HTML named entities when working in real XHTML mode (when page is served as application/xhtml+xml). It causes problems with innerHTML - throws exceptions about invalid pointer. This fixes the problem and still makes first element of innerHTML an whitespace entity.

Sorry for additional last-line diff - edited in nano.
