### PR TITLE
Additional tests for Element#makeClipping(), Element#undoClipping()

### DIFF
--- a/test/unit/dom_test.js
+++ b/test/unit/dom_test.js
@@ -676,14 +676,24 @@ new Test.Unit.Runner({
     this.assertEqual(chained, chained.undoClipping());
     this.assertEqual(chained, chained.undoClipping().makeClipping());
     
-    ['hidden','visible','scroll'].each( function(overflowValue) {
-      var element = $('element_with_'+overflowValue+'_overflow');
-      
-      this.assertEqual(overflowValue, element.getStyle('overflow'));
+    var items = [
+      {id: 'hidden', inline: 'hidden', computed: 'hidden'},
+      {id: 'visible', inline: 'visible', computed: 'visible'},
+      {id: 'scroll', inline: 'scroll', computed: 'scroll'},
+      {id: 'auto', inline: 'auto', computed: null},
+      {id: 'empty', inline: '', computed: 'visible'}
+    ];
+
+    items.each(function(item) {
+      var element = $('element_with_' + item.id + '_overflow');
+      this.assertEqual(item.inline, element.style.overflow, 'inline style');
+      this.assertEqual(item.computed, element.getStyle('overflow'), 'computed style');
       element.makeClipping();
+      this.assertEqual('hidden', element.style.overflow);
       this.assertEqual('hidden', element.getStyle('overflow'));
       element.undoClipping();
-      this.assertEqual(overflowValue, element.getStyle('overflow'));
+      this.assertEqual(item.inline, element.style.overflow, 'restored inline style');
+      this.assertEqual(item.computed, element.getStyle('overflow'), 'restored computed style');
     }, this);
   },
   


### PR DESCRIPTION
See ticket #1063:
1. Current implementation doesn't work properly for inline `style="overflow:auto;"`
2. Inline style isn't restored properly after undoClipping() - it is replaced with computed style
3. Computing style with `Element.getStyle()` isn't needed - performance optimization is possible
