### PR TITLE
Removed `Element.extend` from `_element` accordingly to comment "use it ...

### DIFF
--- a/src/prototype/dom/event.js
+++ b/src/prototype/dom/event.js
@@ -244,10 +244,7 @@
 
     // Fix a Safari bug where a text node gets passed as the target of an
     // anchor click rather than the anchor itself.
-    if (node.nodeType == Node.TEXT_NODE)
-      node = node.parentNode;
-
-    return Element.extend(node);
+    return node.nodeType == Node.TEXT_NODE ? node.parentNode : node;
   }
 
   /**
@@ -275,10 +272,10 @@
    *      });
   **/
   function findElement(event, expression) {
-    var element = _element(event), match = Prototype.Selector.match;
+    var element = _element(event), selector = Prototype.Selector;
     if (!expression) return Element.extend(element);
     while (element) {
-      if (Object.isElement(element) && match(element, expression))
+      if (Object.isElement(element) && selector.match(element, expression))
         return Element.extend(element);
       element = element.parentNode;
     }


### PR DESCRIPTION
...internally as `_element` without having to extend the node".

Restored `selector.match` in `findElement` because it may rely on `this`.
