### PR TITLE
Short-circuit for Element#down() without arguments

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -1775,6 +1775,7 @@
    *      // -> undefined
   **/
   function down(element, expression, index) {
+    if (arguments.length === 1) return firstDescendant(element);
     element = $(element), expression = expression || 0, index = index || 0;
     
     if (Object.isNumber(expression))


### PR DESCRIPTION
Prevent selecting ALL descendants with `Prototype.Selector.select('*', element)` when invoking Element#down() without arguments
