### PR TITLE
Bug fix for 1.7.1 regression in Form.serialize(true/false)

### DIFF
--- a/src/prototype/dom/form.js
+++ b/src/prototype/dom/form.js
@@ -122,14 +122,14 @@ var Form = {
       accumulator = function(result, key, values) {
         if (!Object.isArray(values)) {values = [values];}
         if (!values.length) {return result;}
-        var encodedKey = encodeURIComponent(key);
+        // According to the spec, spaces should be '+' rather than '%20'.
+        var encodedKey = encodeURIComponent(key).gsub(/%20/, '+');
         return result + (result ? "&" : "") + values.map(function (value) {
           // Normalize newlines as \r\n because the HTML spec says newlines should
           // be encoded as CRLFs.
           value = value.gsub(/(\r)?\n/, '\r\n');
           value = encodeURIComponent(value);
-          // Likewise, according to the spec, spaces should be '+' rather than
-          // '%20'.
+          // According to the spec, spaces should be '+' rather than '%20'.
           value = value.gsub(/%20/, '+');
           return encodedKey + "=" + value;
         }).join("&");

--- a/test/unit/fixtures/form.html
+++ b/test/unit/fixtures/form.html
@@ -118,7 +118,7 @@
 </form>
 
 <form id="form_with_inputs_needing_encoding" style="display:none">
-  <input type="hidden" name="user[wristbands][][nickname]" id="fine_1" value="Hässlich" />
+  <input type="hidden" name="user[wristbands][ ][nickname]" id="fine_1" value="Hässlich" />
 </form>
 
 <form id="form_with_troublesome_input_names">

--- a/test/unit/form_test.js
+++ b/test/unit/form_test.js
@@ -301,7 +301,7 @@ new Test.Unit.Runner({
   },
   
   testFormSerializeURIEncodesInputs: function() {
-    this.assertEqual("user%5Bwristbands%5D%5B%5D%5Bnickname%5D=H%C3%A4sslich", $('form_with_inputs_needing_encoding').serialize(false));
+    this.assertEqual("user%5Bwristbands%5D%5B+%5D%5Bnickname%5D=H%C3%A4sslich", $('form_with_inputs_needing_encoding').serialize(false));
   },
   
   testFormMethodsOnExtendedElements: function() {


### PR DESCRIPTION
This patch fixes bugs in both of the form serialization accumulators when it comes to handling multiple selects properly. Test cases included. See problem description in:

https://prototype.lighthouseapp.com/projects/8886-prototype/tickets/1384-formserializeelements-does-not-consider-select-multiple-fails
https://prototype.lighthouseapp.com/projects/8886-prototype/tickets/1386-regression-prototypejs-171-formserialize-is-incompatible-with-multiselects
