### PR TITLE
Short-circuit HAS_EXTENDED_CREATE_ELEMENT_SYNTAX

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -121,7 +121,7 @@
   }
   
   // IE requires that `name` and `type` attributes be set this way.
-  var HAS_EXTENDED_CREATE_ELEMENT_SYNTAX = (function(){
+  var HAS_EXTENDED_CREATE_ELEMENT_SYNTAX = Prototype.Browser.IE && (function(){
     try {
       var el = document.createElement('<input name="x">');
       return el.tagName.toLowerCase() === 'input' && el.name === 'x';


### PR DESCRIPTION
HAS_EXTENDED_CREATE_ELEMENT_SYNTAX may be true only in IE8 and below (and is used only as a workaround for IE specific bug), so testing this feature in non-IE browsers doesn't have sense and only wastes time.
