### PR TITLE
Prevent IE leaks

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3470,9 +3470,8 @@
   Element.addMethods(methods);
 
   // Prevent IE leaks on DIV and ELEMENT_CACHE
-  DIV = null;
-
   function destroyCache_IE() {
+    DIV = null;
     ELEMENT_CACHE = null;
   }
 


### PR DESCRIPTION
Without fix:

 - when `ELEMENT_CACHE` is not empty (e.g. `SPAN` was created with `new Element('span'))`, IE will leak memory for `DIV` and `ELEMENT_CACHE` after page unload.
 - when `ELEMENT_CACHE` is empty, `DIV` is cleaned correctly without any additional actions.

Problem detected and fix tested in sIEve-0.0.8.
