### PR TITLE
Fix for #1339, setOpacity IE regression in 1.7.1

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -2912,7 +2912,7 @@
   }
   
   function hasLayout_IE(element) {
-    if (!element.currentStyle.hasLayout)
+    if (!element.currentStyle || !element.currentStyle.hasLayout)
       element.style.zoom = 1;
     return element;
   }

--- a/test/unit/dom_test.js
+++ b/test/unit/dom_test.js
@@ -903,7 +903,10 @@ new Test.Unit.Runner({
     this.assert(
       $('style_test_3').setOpacity(0.9999999).getStyle('opacity') > 0.999
     );
-    
+
+    // setting opacity before element was added to DOM
+    this.assertEqual(0.5, new Element('div').setOpacity(0.5).getOpacity());
+
     /*
     
     IE <= 7 needs a `hasLayout` for opacity ("filter") to function properly
@@ -927,10 +930,9 @@ new Test.Unit.Runner({
     
     if (ZOOM_AFFECT_HAS_LAYOUT) {
       this.assert($('style_test_4').setOpacity(0.5).currentStyle.hasLayout);
-      this.assert(2, $('style_test_5').setOpacity(0.5).getStyle('zoom'));
-      this.assert(0.5, new Element('div').setOpacity(0.5).getOpacity());
-      this.assert(2, new Element('div').setOpacity(0.5).setStyle('zoom: 2;').getStyle('zoom'));
-      this.assert(2, new Element('div').setStyle('zoom: 2;').setOpacity(0.5).getStyle('zoom'));
+      this.assertEqual(1, $('style_test_5').setOpacity(0.5).getStyle('zoom'));
+      this.assertEqual(2, new Element('div').setOpacity(0.5).setStyle('zoom: 2;').getStyle('zoom'));
+      this.assertEqual(2, new Element('div').setStyle('zoom: 2;').setOpacity(0.5).getStyle('zoom'));
     }
   },
   


### PR DESCRIPTION
This commit fixes a problem introduced in prototype.js 1.7.1 that makes it impossible to set opacity on an element before adding it to the DOM tree. Includes relevant test case.

https://prototype.lighthouseapp.com/projects/8886/tickets/1339-ie9-error-in-haslayout_ie
