### PR TITLE
Fix for ticket 1282

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3012,7 +3012,10 @@
     getOpacity: getOpacity
   });
 
-  if ('styleFloat' in DIV.style) {
+  if (Prototype.Browser.Opera) {
+    // Opera also has 'styleFloat' in DIV.style
+    methods.getStyle = getStyle_Opera;
+  } else if ('styleFloat' in DIV.style) {
     methods.getStyle = getStyle_IE;
     methods.setOpacity = setOpacity_IE;
     methods.getOpacity = getOpacity_IE;


### PR DESCRIPTION
Attempt to fix https://prototype.lighthouseapp.com/projects/8886/tickets/1282-latest-prototypejs-from-github-repo-fails-in-opera

Opera (at least 11.X) has false positive result in feature test `'styleFloat' in DIV.style`, but should have its own `getStyle_Opera` and standard `setOpacity`/`getOpacity`.

Another variant:

``` javascript
  if (Prototype.Browser.Opera) {
    // Opera also has 'styleFloat' in DIV.style
    methods.getStyle = getStyle_Opera;
  } else if ('styleFloat' in DIV.style) {
    methods.getStyle = getStyle_IE;
  }
  if (!STANDARD_CSS_OPACITY_SUPPORTED) {
    methods.setOpacity = setOpacity_IE;
    methods.getOpacity = getOpacity_IE;
  }
```
