### PR TITLE
Added default value for getter when key does not exist.

### DIFF
--- a/src/prototype/lang/hash.js
+++ b/src/prototype/lang/hash.js
@@ -128,9 +128,11 @@ var Hash = Class.create(Enumerable, (function() {
   }
 
   /**
-   *  Hash#get(key) -> value
+   *  Hash#get(key, default) -> value
    *
    *  Returns the stored value for the given `key`.
+   *
+   *  If such key is not defined, returns value passed as default value.
    *
    *  ##### Examples
    *
@@ -138,10 +140,12 @@ var Hash = Class.create(Enumerable, (function() {
    *      h.get('a');
    *      // -> 'apple'
   **/
-  function get(key) {
+  function get(key, def) {
     // simulating poorly supported hasOwnProperty
     if (this._object[key] !== Object.prototype[key])
       return this._object[key];
+
+    return def;
   }
 
   /**

--- a/test/unit/hash_test.js
+++ b/test/unit/hash_test.js
@@ -17,6 +17,9 @@ new Test.Unit.Runner({
 
     this.assertUndefined($H({}).get('toString'));
     this.assertUndefined($H({}).get('constructor'));
+
+    var def = 'foo';
+    this.assertEqual(def, $H({}).get('a', def));
   },
   
   testUnset: function() {


### PR DESCRIPTION
It does not produce any side effects like BC-breaks - when parameter is not specified it is `undefined`, just like previous method implementation - was not returning anything.
