### PR TITLE
viewportOffset: extend forElement (it's used twice)

### DIFF
--- a/src/prototype/dom/layout.js
+++ b/src/prototype/dom/layout.js
@@ -1144,7 +1144,8 @@
   function viewportOffset(forElement) {
     var valueT = 0, valueL = 0, docBody = document.body;
 
-    var element = $(forElement);
+    forElement = $(forElement);
+    var element = forElement;
     do {
       valueT += element.offsetTop  || 0;
       valueL += element.offsetLeft || 0;


### PR DESCRIPTION
`forElement` was used twice in `viewportOffset`:
1. at line 1147 as `var element = $(forElement);`
2. at line 1156 as `element = forElement;`
This leads to error when `forElement` is string: `Element.viewportOffset('id')`
