### PR TITLE
Possibility to remove X-* headers for CORS request

### DIFF
--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -259,8 +259,10 @@ Ajax.Request = Class.create(Ajax.Base, {
         $H(extras).each(function(pair) { headers[pair.key] = pair.value });
     }
 
+    // skip null or undefined values
     for (var name in headers)
-      this.transport.setRequestHeader(name, headers[name]);
+      if (headers[name] != null)
+        this.transport.setRequestHeader(name, headers[name]);
   },
 
   /**


### PR DESCRIPTION
`Ajax.Request#setRequestHeaders()` unconditionally adds specific headers to any request.

This patch gives possibility to remove these headers in order to allow simple CORS request.

Based on [Stack Overflow question](http://stackoverflow.com/questions/13814739/prototype-ajax-request-being-sent-as-options-rather-than-get-results-in-501-err) and [Ticket 1590](https://prototype.lighthouseapp.com/projects/8886/tickets/1590-ability-to-remove-headers-in-ajaxrequestsetrequestheaders-for-cors)
