### PR TITLE
IE8 fix for the opacity check

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3000,7 +3000,7 @@
     var filter = Element.getStyle(element, 'filter');
     if (filter.length === 0) return 1.0;
     var match = (filter || '').match(/alpha\(opacity=(.*)\)/);
-    if (match[1]) return parseFloat(match[1]) / 100;
+    if (match && match[1]) return parseFloat(match[1]) / 100;
     return 1.0;
   }
   


### PR DESCRIPTION
IE8 fails to set the `match` variable which throws a javascript error 

```
'1' is null or not an object.
```

 Check before `match` is used to prevent that from happening.

This was discovered by using script.aculo.us and running the `appear()` method on a div element. IE8 errored but other browsers did not.

Sorry about the mess - I think this should be the correct changes
