### PR TITLE
Added standard Methods to SVG Elements

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3414,6 +3414,10 @@
     if (F.ElementExtensions) {
       mergeMethods(ELEMENT_PROTOTYPE, Element.Methods);
       mergeMethods(ELEMENT_PROTOTYPE, Element.Methods.Simulated, true);
+      if(typeof SVGElement !== 'undefined' && typeof SVGElement.prototype !== 'undefined'){
+        mergeMethods(SVGElement.prototype, Element.Methods);
+        mergeMethods(SVGElement.prototype, Element.Methods.Simulated, true);
+      }
     }
     
     if (F.SpecificElementExtensions) {


### PR DESCRIPTION
https://prototype.lighthouseapp.com/projects/8886/tickets/1655-include-svgand-others-elements-support

I've added some changes to dom.js to add the standard methods to SVGElements, but didn't know if this was something to address.

I've tested on IE6-IE10 it fails silently on IE6-8 and works on IE9 and 10

also tested on Firefox/Chrome/Safari

If SVGElements should not have these methods or need a smaller set of methods I can do that too
