### PR TITLE
toQueryParams doesn't decode '+' signs in the query string according to specs

### DIFF
--- a/src/prototype/lang/string.js
+++ b/src/prototype/lang/string.js
@@ -473,8 +473,11 @@ Object.extend(String.prototype, (function() {
       if ((pair = pair.split('='))[0]) {
         var key = decodeURIComponent(pair.shift()),
             value = pair.length > 1 ? pair.join('=') : pair[0];
-            
-        if (value != undefined) value = decodeURIComponent(value);
+
+        if (value != undefined) {
+          value = value.gsub('+', ' ');
+          value = decodeURIComponent(value);
+        }
 
         if (key in hash) {
           if (!Object.isArray(hash[key])) hash[key] = [hash[key]];

--- a/test/unit/hash_test.js
+++ b/test/unit/hash_test.js
@@ -120,6 +120,7 @@ new Test.Unit.Runner({
     this.assertEqual('a=A&b=B&c=C&d=D%23', $H(Fixtures.many).toQueryString());
     this.assertEqual("a=b&c",              $H(Fixtures.value_undefined).toQueryString());
     this.assertEqual("a=b&c",              $H("a=b&c".toQueryParams()).toQueryString());
+    this.assertEqual("a=b+d&c",            $H("a=b+d&c".toQueryParams()).toQueryString());
     this.assertEqual("a=b&c=",             $H(Fixtures.value_null).toQueryString());
     this.assertEqual("a=b&c=0",            $H(Fixtures.value_zero).toQueryString());
     this.assertEqual("color=r&color=g&color=b", $H(Fixtures.multiple).toQueryString());

--- a/test/unit/string_test.js
+++ b/test/unit/string_test.js
@@ -390,7 +390,8 @@ new Test.Unit.Runner({
     this.assertHashEqual({a:undefined}, 'a'.toQueryParams(), 'key without value');
     this.assertHashEqual({a:'b'},  'a=b&=c'.toQueryParams(), 'empty key');
     this.assertHashEqual({a:'b', c:''}, 'a=b&c='.toQueryParams(), 'empty value');
-    
+    this.assertHashEqual({a:'  '}, 'a=++'.toQueryParams(), 'value of spaces');
+
     this.assertHashEqual({'a b':'c', d:'e f', g:'h'},
       'a%20b=c&d=e%20f&g=h'.toQueryParams(), 'proper decoding');
     this.assertHashEqual({a:'b=c=d'}, 'a=b=c=d'.toQueryParams(), 'multiple equal signs');


### PR DESCRIPTION
Hello,

  I tried to upgrade my app "Checkvist" to prototype 1.7.1 and faced this bug. Looks like operation toQueryParam().toQueryString doesn't work correctly with spaces in the query string.

  The fix illustrates the problem.

  Thanks,
  KIR
