### PR TITLE
IE7 bugfix for getOffsetParent if non-inline element with offsetParent==HTML

### DIFF
--- a/src/prototype/dom/layout.js
+++ b/src/prototype/dom/layout.js
@@ -1059,7 +1059,7 @@
 
     // IE reports offset parent incorrectly for inline elements.
     var isInline = (Element.getStyle(element, 'display') === 'inline');
-    if (!isInline && element.offsetParent) return $(element.offsetParent);
+    if (!isInline && element.offsetParent) return isHtml(element.offsetParent) ? $(document.body) : $(element.offsetParent);
     
     while ((element = element.parentNode) && element !== document.body) {
       if (Element.getStyle(element, 'position') !== 'static') {


### PR DESCRIPTION
Sometimes in IE7 there element.offsetParent return HTML element. In this case it's makes sense to check if offsetParent is HTML element and return document.body if so.
The same method used for nearest parent node with position !== 'static'.
