### PR TITLE
Fix: Ajax.Request considers timeout/connection close to be a success.

### DIFF
--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -272,6 +272,10 @@ Ajax.Request = Class.create(Ajax.Base, {
   **/
   success: function() {
     var status = this.getStatus();
+    // status = 0 is also returned upon timeout and connection
+    // close
+    if (!status && ('' == this.transport.getAllResponseHeaders()))
+      return false;
     return !status || (status >= 200 && status < 300) || status == 304;
   },
 

--- a/test/unit/ajax_test.js
+++ b/test/unit/ajax_test.js
@@ -387,5 +387,31 @@ new Test.Unit.Runner({
     } else {
       this.info(message);
     }
+  },
+
+  testReportConnectionBroken: function() {
+    if (this.isRunningFromRake) {
+      var successTriggered = false,
+	  failureTriggered = false,
+	  exceptionTriggered = false;
+
+      new Ajax.Request("/down", extendDefault({
+	onSuccess: function(transport) {
+	  successTriggered = true;
+	}.bind(this),
+	onFailure: function(transport) {
+	  failureTriggered = true;
+	}.bind(this),
+	onException: function() {
+	  // onException will not trigger for asynchronous
+	  // requests
+	  exceptionTriggered = true;
+	}
+      }));
+
+      this.assertEqual(successTriggered, false, 'a request timeout is no success');
+      this.assertEqual(failureTriggered, true, 'a request timeout is a failure');
+      this.assertEqual(exceptionTriggered, true, 'a synchronous request timeout throws an exception');
+    }
   }
 });


### PR DESCRIPTION
Hey, it's quite possible to never run into this, but the `Ajax.Request` object doesn't seem to handle the case when a connection times out.  An exception is thrown when the request is made synchronously, but even then the `onSuccess` callback will trigger.

The `XMLHTTPRequest` specification, at least in its older incarnation, doesn't really account for connection errors; testing for an empty header string is a plausible workaround that seems to work on all browsers.

Note that the included unit test is rather clunky, as it actually waits for a timeout on a synchronous request.  The failure can also be triggered by making the webserver close the connection (without sending any response), but I've been unable to cajole Webrick into doing that.
