### PR TITLE
Add succ method for Date object

### DIFF
--- a/src/prototype/lang/date.js
+++ b/src/prototype/lang/date.js
@@ -48,9 +48,20 @@
   function toJSON() {
     return this.toISOString();
   }
+
+  /**
+   *  Date#succ() -> Date
+   *
+   *  Returns the successor of the current [[Date]], as defined by current + one day.
+   *  Used to make dates compatible with [[ObjectRange]].
+  **/
+  function succ() {
+    return new Date(this.getTime() + 86400000);
+  }
   
   if (!proto.toISOString) proto.toISOString = toISOString;
   if (!proto.toJSON) proto.toJSON = toJSON;
+  if (!proto.succ) proto.succ = succ;
   
 })(Date.prototype);
 

--- a/test/unit/date_test.js
+++ b/test/unit/date_test.js
@@ -5,5 +5,10 @@ new Test.Unit.Runner({
   
   testDateToISOString: function() {
     this.assertMatch(/^1970-01-01T00:00:00(\.000)?Z$/, new Date(Date.UTC(1970, 0, 1)).toISOString());
+  },
+
+  testSucc: function() {
+    this.assertEqual((new Date(2016, 1, 29)).succ().getTime(), (new Date(2016, 2, 1)).getTime());
   }
+
 });

--- a/test/unit/range_test.js
+++ b/test/unit/range_test.js
@@ -11,6 +11,12 @@ new Test.Unit.Runner({
     this.assert($R(0, 5, false).include(0));
     this.assert($R(0, 5, false).include(5));
     this.assert(!$R(0, 5, false).include(6));
+
+    var a = new Date(2013, 0, 1);
+    var b = new Date(2014, 1, 1);
+    this.assert($R(a, b).include(b));
+    this.assert($R(a, b).include(new Date(2013, 1, 1)));
+    this.assert(!$R(a, b, true).include(b));
   },
 
   testEach: function() {


### PR DESCRIPTION
Hi.
I added `succ` method for `Date` object. Now possible use Date-object for `Ranges`.
