### PR TITLE
fixes issue #3284

### DIFF
--- a/src/prototype/dom/layout.js
+++ b/src/prototype/dom/layout.js
@@ -1114,8 +1114,8 @@
       }
     } while (element);
     
-    valueL -= layout.get('margin-top');
-    valueT -= layout.get('margin-left');
+    valueT -= layout.get('margin-top');
+    valueL -= layout.get('margin-left');
     
     return new Element.Offset(valueL, valueT);
   }


### PR DESCRIPTION
In issue
https://prototype.lighthouseapp.com/projects/8886/tickets/3284

It was pointed out that the variables `valueL` and `valueT` were flipped by mistake.
