### PR TITLE
include perf boost as well as ECMA6 detect for include or contains

### DIFF
--- a/src/prototype/lang/string.js
+++ b/src/prototype/lang/string.js
@@ -769,7 +769,7 @@ Object.extend(String.prototype, (function() {
    *      //-> false
   **/
   function include(pattern) {
-    return this.indexOf(pattern) > -1;
+    return this.indexOf(pattern) !== -1;
   }
 
   /**
@@ -910,7 +910,8 @@ Object.extend(String.prototype, (function() {
     unfilterJSON:   unfilterJSON,
     isJSON:         isJSON,
     evalJSON:       NATIVE_JSON_PARSE_SUPPORT ? parseJSON : evalJSON,
-    include:        include,
+    //ECMA 6 supports contains(), if it exists map include() to contains()
+    include:        String.prototype.contains || include,
     // Firefox 18+ supports String.prototype.startsWith, String.prototype.endsWith
     startsWith:     String.prototype.startsWith || startsWith,
     endsWith:       String.prototype.endsWith || endsWith,


### PR DESCRIPTION
Based on the proposed polyfill for ECMA6 for `String.prototype.contains()`

http://wiki.ecmascript.org/doku.php?id=harmony:string_extras

using not equivalent to `!==` instead of greater than `>` gets a performance boost according to
http://jsperf.com/string-contains

as well as add the detection if `String.prototype.contains()` exists then map `include()` to that
