### PR TITLE
Add Touch to Prototype.BrowserFeatures

### DIFF
--- a/src/prototype/prototype.js
+++ b/src/prototype/prototype.js
@@ -136,7 +136,13 @@ var Prototype = {
       div = form = null;
 
       return isSupported;
-    })()
+    })(),
+    /**
+     *  Prototype.BrowserFeatures.Touch -> Boolean
+     *
+     *  Detects if the browser supports touch interaction.
+    **/
+    Touch: navigator.msMaxTouchPoints || ('ontouchstart' in document.documentElement)
   },
 
   ScriptFragment: '<script[^>]*>([\\S\\s]*?)<\/script\\s*>',


### PR DESCRIPTION
I have added Touch to Prototype.BrowserFeatures according to http://stackoverflow.com/questions/3974827/detecting-touch-screen-devices-with-javascript/3996900#comment-21579245 which I find useful. Perhaps others find this useful too?
