### PR TITLE
Add space to separate existing filters from alpha filter

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -2998,7 +2998,7 @@
     if (value < 0.00001) value = 0;
         
     style.filter = stripAlphaFromFilter_IE(filter) + 
-     'alpha(opacity=' + (value * 100) + ')';
+     ' alpha(opacity=' + (value * 100) + ')';
      
     return element;
   }


### PR DESCRIPTION
In IE <= 8 it was impossible to setOpacity on an element that already had an existing filter such as filter: FlipH; The filters need to be space seperated
