### PR TITLE
Use Element.matches if available

### DIFF
--- a/src/sizzle.js
+++ b/src/sizzle.js
@@ -1215,7 +1215,7 @@ if ( document.querySelectorAll ) {
 
 (function(){
 	var html = document.documentElement,
-		matches = html.matchesSelector || html.mozMatchesSelector || html.webkitMatchesSelector || html.msMatchesSelector;
+		matches = html.matches || html.mozMatchesSelector || html.webkitMatchesSelector || html.msMatchesSelector;
 
 	if ( matches ) {
 		// Check to see if it's possible to do matchesSelector


### PR DESCRIPTION
Spec:
http://dom.spec.whatwg.org/#dom-element-matches

Support in Chromium:
https://code.google.com/p/chromium/issues/detail?id=326652

Backported from https://github.com/jquery/sizzle/pull/251

Element.matchesSelector was never standardized and it is not available
in the most recent versions of Blink, Gecko, Presto, Trident or WebKit.
