### PR TITLE
IE8 fix: node is null on IE8, causing an error

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -2395,8 +2395,7 @@
     var checkbox = document.createElement('<input type="checkbox">');
     checkbox.checked = true;
     var node = checkbox.getAttributeNode('checked');
-    var buggy = !node.specified;
-    return !node.specified;
+    return !node || !node.specified;
   })();
   
   function hasAttribute(element, attribute) {


### PR DESCRIPTION
This is fatal on IE8 ... at least that it prevents prototype.js from working.

"buggy" didn't seem to be used either, so removed it also.
