### PR TITLE
fix layout.js for opera 12

### DIFF
--- a/src/prototype/dom/layout.js
+++ b/src/prototype/dom/layout.js
@@ -55,7 +55,8 @@
     return boxWidth - bl - br - pl - pr;
   }
   
-  if ('currentStyle' in document.documentElement) {
+  //old opera also has currentStyle
+  if (!Object.isUndefined(document.documentElement.currentStyle) && !Prototype.Browser.Opera) {
     getRawStyle = getRawStyle_IE;
   }
   


### PR DESCRIPTION
Opera 12.16 fix, because a `document.documentElement` has a `currentStyle` property. And a test `layout on elements with display: none ancestors` failed.