### PR TITLE
Minor regex fix for stripTags

### DIFF
--- a/src/prototype/lang/string.js
+++ b/src/prototype/lang/string.js
@@ -283,7 +283,7 @@ Object.extend(String.prototype, (function() {
    *      // -> 'a link'
   **/
   function stripTags() {
-    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>])+)?>|<\/\w+>/gi, '');
+    return this.replace(/<\w+(\s+("[^"]*"|'[^']*'|[^>])+)?(\/)?>|<\/\w+>/gi, '');
   }
 
   /**

--- a/test/unit/string_test.js
+++ b/test/unit/string_test.js
@@ -214,6 +214,8 @@ new Test.Unit.Runner({
     this.assertEqual('hello world', 'h<b><em>e</em></b>l<i>l</i>o w<span class="moo" id="x"><b>o</b></span>rld'.stripTags());
     this.assertEqual('1\n2', '1\n2'.stripTags());
     this.assertEqual('one < two blah baz', 'one < two <a href="#" title="foo > bar">blah</a> <input disabled>baz'.stripTags());
+    this.assertEqual('hello world abc', 'hello world <br/>abc'.stripTags());
+    this.assertEqual('hello world abc', 'hello world <br />abc'.stripTags());
   },
   
   testStripScripts: function() {


### PR DESCRIPTION
I made some changes, please review.

Modified the regular expression to work for empty tags with no spaces, eg.
          `<br/>`