### PR TITLE
Solves #152 by returning false when the ancestor is null

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -2150,6 +2150,7 @@
   }
   
   function descendantOf_compareDocumentPosition(element, ancestor) {
+    if (!ancestor) return false; //fixes #152
     element = $(element), ancestor = $(ancestor);
     return (element.compareDocumentPosition(ancestor) & 8) === 8;
   }


### PR DESCRIPTION
Please merge this one that fixes this firefox bug that my customers experienced recently
Thanks!