### PR TITLE
Form.Element.clear() works on Checkbox and Radio Buttons

### DIFF
--- a/src/prototype/dom/form.js
+++ b/src/prototype/dom/form.js
@@ -603,7 +603,13 @@ Form.Element.Methods = {
    *        }
   **/
   clear: function(element) {
-    $(element).value = '';
+    var elementType = $(element).type;
+
+    if(elementType === "checkbox" || elementType === "radio")
+        element.checked = false;
+    else
+        $(element).value = '';
+
     return element;
   },
 


### PR DESCRIPTION
Form.Element.clear() un-checks checkboxes and radio buttons.
