### PR TITLE
Issue #262: Creating elements with a checked:false attribute wrongly checks the new element in some browsers

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -2371,7 +2371,7 @@
       name = table.names[attr] || attr;
       value = attributes[attr];
       if (table.values[attr])
-        name = table.values[attr](element, value) || name;
+        value = table.values[attr](element, value);
       if (value === false || value === null)
         element.removeAttribute(name);
       else if (value === true)
@@ -2659,11 +2659,11 @@
     
     values: {
       checked: function(element, value) {
-        element.checked = !!value;
+        return element.checked = !!value;
       },
       
       style: function(element, value) {
-        element.style.cssText = value ? value : '';
+        return element.style.cssText = value ? value : '';
       }
     }
   };


### PR DESCRIPTION
Fixed.

This is a regression introduced by 4a22a52e08fce7dfe95bf54b8f52314614ee24b3