### PR TITLE
Added unsetting of 'Element' to prevent memory leak in IE8

### DIFF
--- a/src/prototype/dom/dom.js
+++ b/src/prototype/dom/dom.js
@@ -3519,10 +3519,12 @@
 
   Element.addMethods(methods);
 
-  // Prevent IE leaks on DIV and ELEMENT_CACHE
+  // Prevent IE leaks on DIV, ELEMENT_CACHE and Element
   function destroyCache_IE() {
     DIV = null;
     ELEMENT_CACHE = null;
+    // Prevent leak invisible to sIEve in IE8 Standards mode in IE8
+    Element = null;
   }
 
   if (window.attachEvent)


### PR DESCRIPTION
Fixes leak in IE8 Standards mode in IE8 v8.0.7601.17514 (not visible in Quirks mode)