### PR TITLE
Support for other Request Methods than `get` and `post`

### DIFF
--- a/src/prototype/ajax.js
+++ b/src/prototype/ajax.js
@@ -53,6 +53,9 @@
  *    conventions, Prototype also reacts to other HTTP verbs (such as `put` and
  *    `delete`) by submitting via `post` and adding a extra `_method` parameter
  *    with the originally-requested method.
+ *    To support other HTTP methods, you can set `Ajax.Request.supportedHTTPMethods`
+ *    to an array including the allowed methods, e.g.:
+ *    `Ajax.Request.supportedHTTPMethods = ['get','post','put','delete'];`
  *  * `parameters` ([[String]]): The parameters for the request, which will be
  *    encoded into the URL for a `get` method, or into the request body for the
  *    other methods. This can be provided either as a URL-encoded string, a

--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -182,8 +182,8 @@ Ajax.Request = Class.create(Ajax.Base, {
     var params = Object.isString(this.options.parameters) ?
           this.options.parameters :
           Object.toQueryString(this.options.parameters);
-
-    if (!['get', 'post'].include(this.method)) {
+    
+    if (!Ajax.Request.supportedHTTPMethods.include(this.method)) {
       // simulate other verbs over post
       params += (params ? '&' : '') + "_method=" + this.method;
       this.method = 'post';
@@ -355,3 +355,5 @@ Ajax.Request = Class.create(Ajax.Base, {
 
 Ajax.Request.Events =
   ['Uninitialized', 'Loading', 'Loaded', 'Interactive', 'Complete'];
+
+Ajax.Request.supportedHTTPMethods = ['get','post'];

--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -182,7 +182,7 @@ Ajax.Request = Class.create(Ajax.Base, {
     var params = Object.isString(this.options.parameters) ?
           this.options.parameters :
           Object.toQueryString(this.options.parameters);
-    
+
     if (!Ajax.Request.supportedHTTPMethods.include(this.method)) {
       // simulate other verbs over post
       params += (params ? '&' : '') + "_method=" + this.method;


### PR DESCRIPTION
Added a simple possibility to support other HTTP methods, without breaking the default:

One can just set the static `Ajax.Request.supportedHTTPMethods` array. Example:

```javascript
Ajax.Request.supportedHTTPMethods = ['get','post','put','delete'];
new Ajax.Request('/backend/url', {method: 'delete'});
```

If you find this useful, it would be great. It would really improve the library usage for our own projects.