### PR TITLE
Added new method for Object class, Object #isObject

### DIFF
--- a/src/prototype/lang/object.js
+++ b/src/prototype/lang/object.js
@@ -29,6 +29,7 @@
       NUMBER_TYPE = 'Number',
       STRING_TYPE = 'String',
       OBJECT_TYPE = 'Object',
+      OBJECT_CLASS = '[object Object]';
       FUNCTION_CLASS = '[object Function]',
       BOOLEAN_CLASS = '[object Boolean]',
       NUMBER_CLASS = '[object Number]',
@@ -487,6 +488,24 @@
   }
 
   /**
+   *  Object.isObject(object) -> Boolean
+   *  - object (Object): The object to test.
+   *
+   *  Returns `true` if `object` is of type [[Object]]; `false` otherwise.
+   *  
+   *  ##### Examples
+   *  
+   *      Object.isObject({});
+   *      //-> true
+   *      
+   *      Object.isObject('str');
+   *      //-> false
+  **/
+  function isObject(object) {
+    return _toString.call(object) === OBJECT_CLASS;
+  }
+
+  /**
    *  Object.isFunction(object) -> Boolean
    *  - object (Object): The object to test.
    *
@@ -603,6 +622,7 @@
     keys:          Object.keys || keys,
     values:        values,
     clone:         clone,
+    isObject:      isObject,
     isElement:     isElement,
     isArray:       isArray,
     isHash:        isHash,

--- a/test/unit/tests/object.test.js
+++ b/test/unit/tests/object.test.js
@@ -143,6 +143,19 @@ suite('Object', function () {
     assert.strictEqual(false, Object.isElement(undefined));
   });
 
+  test('.isObject', function () {
+    assert(Object.isObject({}));
+    assert(Object.isObject(new Object()));
+
+    assert(!Object.isObject("a string"));
+    assert(!Object.isObject($(document.createElement('div'))));
+    assert(!Object.isObject([]));
+    assert(!Object.isObject(0));
+    assert(!Object.isObject(false));
+    assert(!Object.isObject(undefined));
+    assert(!Object.isObject(/xyz/));
+  });
+
   test('.isFunction', function () {
     assert(Object.isFunction(function() { }));
     assert(Object.isFunction(Class.create()));


### PR DESCRIPTION
Short explanation why I added this API.

I wrote a function which can process the request with variable arguments
case A :  arg0 -> property, arg1 -> value
    or
case B : arg0 -> {properties : values}

So for the case (B), I need to make sure the param is only of type Object else the results will be odd.
Because in javascript `for in` loop can loop over `string` by creating properties 0, 1, 2... for each character the string contains and also over String class properties.

Also most of the utility functions we write takes options/params parameter, which is an object (mostly containing flags) to add additional functionality for any utility. So looping over the options/params will be error free, if we make sure the param is Object type.
This will also **eliminates null check** for options because if the parameter is null/undefined Object.isObject(null) returns false.
