### PR TITLE
adding simple JSONP support

### DIFF
--- a/src/prototype/ajax/ajax.js
+++ b/src/prototype/ajax/ajax.js
@@ -17,5 +17,6 @@ var Ajax = {
    *  Represents the number of active XHR requests triggered through
    *  [[Ajax.Request]], [[Ajax.Updater]], or [[Ajax.PeriodicalUpdater]].
   **/
-  activeRequestCount: 0
+  activeRequestCount: 0,
+  _jsonpfunctions: []
 };

--- a/test/unit/tests/ajax.test.js
+++ b/test/unit/tests/ajax.test.js
@@ -477,6 +477,28 @@ suite("Ajax", function () {
 
     Ajax.Request.prototype.isSameOrigin = isSameOrigin;
   });
+  //
+  // Commented out because I'm not sure how to make WEBRICK and Sinatra handle this JSONP request
+  //
+  // test("JSONP with Same Origin",function(done){
+  //     new Ajax.Request("/jsonp",extendDefault({
+  //       parameters: "handlejsonp=1",
+  //       jsonpparametername:'callback',
+  //       onSuccess: function(transport) {
+  //         assert.equal(transport.responseJSONP.handlejsonp,"1");
+  //         done();
+  //       }
+  //     }))
+  // })
+  test("JSONP with Different Origin",function(done){
+      new Ajax.Request("http://echo.jsontest.com/key/value/one/two",extendDefault({
+        jsonpparametername:'callback',
+        onSuccess: function(transport) {
+          assert.deepEqual(transport.responseJSONP,{"one": "two","key": "value"});
+          done();
+        }
+      }))
+  })
 
 });
 


### PR DESCRIPTION
For issue #197 , this should add transparent JSONP support to all browsers that PrototypeJS supports.

I added unit tests for a cross domain url but was exactly sure how to make WEBrick do it correctly.