### PR TITLE
Add default exception handler to Ajax.Base

### DIFF
--- a/src/prototype/ajax/base.js
+++ b/src/prototype/ajax/base.js
@@ -8,7 +8,8 @@ Ajax.Base = Class.create({
       encoding:     'UTF-8',
       parameters:   '',
       evalJSON:     true,
-      evalJS:       true
+      evalJS:       true,
+      onException:  function(req,ex) { throw ex; },
     };
     Object.extend(this.options, options || { });
 


### PR DESCRIPTION
If this isn't specified, any exception that is generated inside an Ajax call is swallowed, which I think is mostly an undesired effect since execution just stops without any feedback in e.g. the console or the user's outer exception handler.
