### PR TITLE
String#extractScripts evaluates scripts that are not javascript

### DIFF
--- a/src/prototype/lang/string.js
+++ b/src/prototype/lang/string.js
@@ -341,7 +341,9 @@ Object.extend(String.prototype, (function() {
     var matchAll = new RegExp(Prototype.ScriptFragment, 'img'),
         matchOne = new RegExp(Prototype.ScriptFragment, 'im');
     return (this.match(matchAll) || []).map(function(scriptTag) {
-      return (scriptTag.match(matchOne) || ['', ''])[1];
+      var v = scriptTag.match(matchOne);
+      var a = new Element('div').update('<span ' + (v[1] || '') + "></span>").down().readAttribute('type');
+      return (!Object.isUndefined(v) && (!a || Prototype.ExecutableScript.test(a))) ? v[2] : '';
     });
   }
 

--- a/src/prototype/prototype.js
+++ b/src/prototype/prototype.js
@@ -139,7 +139,8 @@ var Prototype = {
     })()
   },
 
-  ScriptFragment: '<script[^>]*>([\\S\\s]*?)<\/script\\s*>',
+  ScriptFragment: '<script([^>]*)>([\\S\\s]*?)<\/script\\s*>',
+  ExecutableScript: /(?:text|application)\/(?:x-)?(?:java|ecma)script/i,
   JSONFilter: /^\/\*-secure-([\s\S]*)\*\/\s*$/,
 
   /**

--- a/test/unit/tests/string.test.js
+++ b/test/unit/tests/string.test.js
@@ -250,6 +250,19 @@ suite('String', function () {
     (3).times(function(){ stringWithScripts += 'foo <script>evalScriptsCounter++<'+'/script>bar' });
     stringWithScripts.evalScripts();
     assert.equal(4, evalScriptsCounter);
+
+	// other executable mime types
+	('foo <script type="text/javascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	('foo <script type="application/javascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	('foo <script type="application/x-javascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	('foo <script type="text/x-javascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	('foo <script type="application/ecmascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	('foo <script type="text/ecmascript">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	assert.equal(10, evalScriptsCounter);
+
+	// a wrong one
+	('foo <script type="text/x-dot-template">evalScriptsCounter++<'+'/script>bar').evalScripts();
+	assert.equal(10, evalScriptsCounter);
   });
 
   test('#escapeHTML', function () {


### PR DESCRIPTION
String#extractScripts passes any scripts in the string to String#evalScripts, regardless of type. To increase integration support with other tools (like handlebars or dot.js) and increase stability a check of the type should be added. Scripts without type should still be evaluated as they default to javascript according to specs. 

I've tried to tackle this by changing the Prototype.ScriptFragment regex, but without success. The submitted code is not perfect, but gets the job done. Alternatives are welcome.
