### PR TITLE
Allow Content-type header to be unchanged

### DIFF
--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -236,8 +236,11 @@ Ajax.Request = Class.create(Ajax.Base, {
     };
 
     if (this.method == 'post') {
-      headers['Content-type'] = this.options.contentType +
-        (this.options.encoding ? '; charset=' + this.options.encoding : '');
+      if (this.options.contentType)
+      {
+        headers['Content-type'] = this.options.contentType +
+          (this.options.encoding ? '; charset=' + this.options.encoding : '');
+      }
 
       /* Force "Connection: close" for older Mozilla browsers to work
        * around a bug where XMLHttpRequest sends an incorrect


### PR DESCRIPTION
This is _crucial_ to be able to do proper `multipart/form-data` requests, otherwise the `boundary` will never get filled correctly!

With this patch if the user sets `contentType` to null/false, the actual `Content-Type` header will be generated (correctly) by the browser.
