### PR TITLE
Added optional support for other http methods (for #280)

### DIFF
--- a/src/prototype/ajax/base.js
+++ b/src/prototype/ajax/base.js
@@ -8,7 +8,8 @@ Ajax.Base = Class.create({
       encoding:     'UTF-8',
       parameters:   '',
       evalJSON:     true,
-      evalJS:       true
+      evalJS:       true,
+      allMethods:   false
     };
     Object.extend(this.options, options || { });
 

--- a/src/prototype/ajax/request.js
+++ b/src/prototype/ajax/request.js
@@ -183,7 +183,7 @@ Ajax.Request = Class.create(Ajax.Base, {
           this.options.parameters :
           Object.toQueryString(this.options.parameters);
 
-    if (!['get', 'post'].include(this.method)) {
+    if (!this.options.allMethods && !['get', 'post'].include(this.method)) {
       // simulate other verbs over post
       params += (params ? '&' : '') + "_method=" + this.method;
       this.method = 'post';
@@ -209,7 +209,7 @@ Ajax.Request = Class.create(Ajax.Base, {
       this.transport.onreadystatechange = this.onStateChange.bind(this);
       this.setRequestHeaders();
 
-      this.body = this.method == 'post' ? (this.options.postBody || params) : null;
+      this.body = this.method !== 'get' ? (this.options.postBody || params) : null;
       this.transport.send(this.body);
 
       /* Force Firefox to handle ready state 4 for synchronous requests */
@@ -235,7 +235,7 @@ Ajax.Request = Class.create(Ajax.Base, {
       'Accept': 'text/javascript, text/html, application/xml, text/xml, */*'
     };
 
-    if (this.method == 'post') {
+    if (this.method !== 'get') {
       headers['Content-type'] = this.options.contentType +
         (this.options.encoding ? '; charset=' + this.options.encoding : '');
 


### PR DESCRIPTION
This is a patch I created for a product a while ago which can serve as a starting point for work on #280. 
- Added the `allMethods` option, which defaults to `false` for backward compatibility
- The `_method` parameter is added when `allMethods` is `false`
- The request body is only set when the method is not GET
- The request content type is set when the method is not GET
