### PR TITLE
Conflict with Google Street View embed

### DIFF
--- a/src/prototype/lang/array.js
+++ b/src/prototype/lang/array.js
@@ -95,11 +95,6 @@ function $w(string) {
   return string ? string.split(/\s+/) : [];
 }
 
-/** alias of: $A
- *  Array.from(iterable) -> Array
-**/
-Array.from = $A;
-
 /** section: Language
  * class Array
  *  includes Enumerable


### PR DESCRIPTION
When prototype and Google StreetView are loaded on the same page, Google Street viewer ceases to respond to mouse events. I tracked it down to `$A()` being aliased as `Array.from`.

As there is no other code that uses Array.from and the next version is going to drop a lot of old support this might be a good time to drop this alias (as it also overwrites the native method as well)

links for details

https://stackoverflow.com/q/50418704/341491

https://issuetracker.google.com/issues/72690631